### PR TITLE
allow user to specify model with specific version

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -16,9 +16,10 @@ const readlineSync = await import('readline-sync').then(module => module.default
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-const defaultArgs = { 'run-after-setup': true }
-const commandLineArgs = minimist(process.argv.slice(2), { boolean: ['run-after-setup'] })
-const args = { ...defaultArgs, ...commandLineArgs }
+const args = minimist(process.argv.slice(2), {
+  boolean: ['run-after-setup'],
+  default: { 'run-after-setup': true }
+})
 
 const targetAppName = args._[0] || 'my-replicate-app'
 const modelName = args.model || 'stability-ai/sdxl'
@@ -31,7 +32,10 @@ try {
   process.exit()
 }
 
-const modelNameWithVersion = getModelNameWithVersion(model)
+// If user has provided a model version, use it. Otherwise, use the latest version
+const modelVersionRegexp = /.*:[a-fA-F0-9]{64}$/
+const modelNameWithVersion = modelName.match(modelVersionRegexp) ? modelName : getModelNameWithVersion(model)
+
 const inputs = getModelInputs(model)
 
 console.log(`Creating project "${targetAppName}"...`)
@@ -74,8 +78,6 @@ const newContents = indexFileContents
 fs.writeFileSync(indexFile, newContents)
 
 console.log('App created successfully!')
-
-console.log({ args })
 
 if (args['run-after-setup']) {
   console.log(`Running command: \`node ${targetAppName}/index.js\`\n\n`)

--- a/index.test.js
+++ b/index.test.js
@@ -48,4 +48,38 @@ describe('Node script test', () => {
     const gitignoreFileContents = fs.readFileSync(gitignoreFile, 'utf8')
     expect(gitignoreFileContents).toBe('.env\n.npmrc')
   })
+
+  it('handles basic `model` argument in the form {owner}/{model}', () => {
+    const command = `REPLICATE_API_TOKEN=test_token node index.mjs ${directoryName} --model=yorickvp/llava-13b --run-after-setup=false`
+
+    execSync(command, { stdio: 'ignore', env: process.env })
+
+    // Check if the directory exists
+    expect(fs.existsSync(directoryName)).toBe(true)
+
+    // Check if index.js exists in the directory
+    const indexFile = path.join(directoryName, 'index.js')
+    expect(fileExists(indexFile)).toBe(true)
+
+    // Check if index.js contains the correct model name
+    const indexFileContents = fs.readFileSync(indexFile, 'utf8')
+    expect(indexFileContents).toMatch(/yorickvp\/llava-13b:[a-zA-Z0-9]{40}/)
+  })
+
+  it('handles a `model` argument in the form {owner}/{model}:{version}', () => {
+    const command = `REPLICATE_API_TOKEN=test_token node index.mjs ${directoryName} --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8 --run-after-setup=false`
+
+    execSync(command, { stdio: 'ignore', env: process.env })
+
+    // Check if the directory exists
+    expect(fs.existsSync(directoryName)).toBe(true)
+
+    // Check if index.js exists in the directory
+    const indexFile = path.join(directoryName, 'index.js')
+    expect(fileExists(indexFile)).toBe(true)
+
+    // Check if index.js contains the correct model name
+    const indexFileContents = fs.readFileSync(indexFile, 'utf8')
+    expect(indexFileContents).toContain("const model = 'yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8'")
+  })
 })

--- a/lib/models.js
+++ b/lib/models.js
@@ -9,7 +9,8 @@ export function getModelNameWithVersion (model) {
 }
 
 export function getModel (fullModelName) {
-  const [owner, modelName] = fullModelName.split('/')
+  // Extract owner and model name, omitting the version if it's present
+  const [owner, modelName] = fullModelName.split(':')[0].split('/')
 
   const model = models.find(model => model.owner === owner && model.name === modelName)
 


### PR DESCRIPTION
Before you could only do this:

```
npm create replicate-app --model=yorickvp/llava-13b
```

Now you can also do this:

```
npm create replicate-app --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8
```

Includes tests.