### PR TITLE
rename it to create-replicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# create-replicate-app
+# create-replicate
 
 Generate a simple Node.js project structure for running AI models with [Replicate](https://replicate.com).
 
@@ -17,23 +17,23 @@ What it does:
 Make sure you have [Node.js](https://nodejs.org/) 18 or greater installed, then run:
 
 ```console
-npm create replicate-app
+npm create replicate
 ```
 
 You can specify an optional name for your project:
 
 ```console
-npm create replicate-app foo
+npm create replicate foo
 ```
 
 You can also specify which model you want to use as a starting point. The latest version of the model will be used:
 
 ```console
-npm create replicate-app my-image-interrogator --model=yorickvp/llava-13b
+npm create replicate my-image-interrogator --model=yorickvp/llava-13b
 ```
 
 You can also specify a version of the model you want to use:
 
 ```console
-npm create replicate-app my-image-interrogator --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8
+npm create replicate my-image-interrogator --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "create-replicate-app",
+  "name": "create-replicate",
   "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "create-replicate-app",
+      "name": "create-replicate",
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
         "readline-sync": "^1.4.10"
       },
       "bin": {
-        "create-replicate-app": "index.cjs"
+        "create-replicate-app": "index.mjs"
       },
       "devDependencies": {
         "standard": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "create-replicate-app",
+  "name": "create-replicate",
   "version": "1.2.1",
   "description": "Generate a simple Node.js project structure for running AI models with Replicate's API",
   "main": "index.js",
@@ -11,7 +11,7 @@
     "lint": "standard --fix",
     "test": "vitest run && standard"
   },
-  "repository": "https://github.com/replicate/create-replicate-app",
+  "repository": "https://github.com/replicate/create-replicate",
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com/)",
   "license": "MIT",
   "preferGlobal": true,


### PR DESCRIPTION
Resolves #1 

We can `npm deprecate` the `create-replicate-app` module on npm afterwards, in case anyone tries to use the old name.

cc @mattt 