### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+on:
+   push:
+     branches:
+       - main
+name: release-please
+
+jobs:
+  release-please:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_PAT }}
+          release-type: node
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install && npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,20 @@
+name: "Semantic Pull Request"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_GITHUB_PAT }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,24 +6,25 @@ Thanks for contributing to this app!
 
 This project uses [standard](https://npm.im/standard) for linting. Please make sure your code passes the linter before submitting a pull request.
 
-## Release
+## Pull Requests
 
-Releases are published manually for now using [np](https://npm.im/np):
+This project follows the Conventional Commits spec to simplify and automate the process of releasing new versions.
 
-Cut a patch release (with a bug fix):
+When opening a pull request, give your PR title a semantic prefix like `fix:`, `feat:`, or `chore:` to indicate what kind of change you're making.
 
-```console
-npx np patch
-```
+Here are some valid example  pull request titles:
 
-Cut a minor release (with a new feature):
+- fix: Correct typo
+- feat: Add support for Node.js 18
+- refactor!: Drop support for Node.js 12 (breaking change)
+- feat(ui): Add `Button` component
 
-```console
-npx np minor
-```
+See [Conventional Commits](https://www.conventionalcommits.org/) for more examples.
 
-Cut a major release (with breaking changes):
+## Release process
 
-```console
-npx np major
-```
+This project uses [Release Please](https://github.com/googleapis/release-please) and GitHub Actions to automate releases.
+
+Release Please automates CHANGELOG generation, the creation of GitHub releases, and version bumps.
+
+Rather than continuously releasing what's landed on the main branch, release-please maintains Release PRs, which are kept up to date as additional work is merged. When we're ready to tag a release, we merge the release PR and the release is published to GitHub and npm automatically.


### PR DESCRIPTION
Uses https://github.com/googleapis/release-please and https://github.com/google-github-actions/release-please-action

- [x] Edit repo settings to allow Actions workflows to open PRs
- [x] Add NPM_TOKEN to secrets
- [x] Add RELEASE_PLEASE_GITHUB_PAT to secrets
- [x] Add Actions workflow that checks for conventional commits
- [x] Configure repo to [only allow squash commits](https://www.npmjs.com/package/release-please#linear-git-commit-history-use-squash-merge)
- [x] Update CONTRIBUTING guide