### PR TITLE
fix: set npm registry url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          registry-url: 'https://registry.npmjs.org/'
           node-version: 20
       - run: npm install && npm publish
         env:


### PR DESCRIPTION
Maybe this is why release CI is failing?

https://github.com/replicate/create-replicate/actions/runs/7834514096