### PR TITLE
fix: favor npx over npm because of flag weirdness

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,4 +19,4 @@ A clear and concise description of what you expected to happen.
 **Environment**
  - OS: 
  - Node.js version (Run `node --version`) 
- - Version (Run `npm create replicate --version`)
+ - Version (Run `npx create-replicate --version`)

--- a/README.md
+++ b/README.md
@@ -17,23 +17,23 @@ What it does:
 Make sure you have [Node.js](https://nodejs.org/) 18 or greater installed, then run:
 
 ```console
-npm create replicate
+npx create-replicate@latest
 ```
 
 You can specify an optional name for your project:
 
 ```console
-npm create replicate foo
+npx create-replicate@latest foo
 ```
 
 You can also specify which model you want to use as a starting point. The latest version of the model will be used:
 
 ```console
-npm create replicate my-image-interrogator --model=yorickvp/llava-13b
+npx create-replicate@latest my-image-interrogator --model=yorickvp/llava-13b
 ```
 
 You can also specify a version of the model you want to use:
 
 ```console
-npm create replicate my-image-interrogator --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8
+npx create-replicate@latest my-image-interrogator --model=yorickvp/llava-13b:2cfef05a8e8e648f6e92ddb53fa21a81c04ab2c4f1390a6528cc4e331d608df8
 ```


### PR DESCRIPTION
This PR updates our instructions to recommend `npx create-replicate` instead of `npm create replicate`.

`npm create replicate` is easier on the eyes, but it doesn't accept flags like `--model` without some unintuitive incantations.

## Why?

If you run `npm` with any **flags** (aka [named parameters](https://clig.dev/#arguments-and-flags)), those get passed to the `npm` binary, instead of the underlying binary you're trying to execute. If you want to pass flags to the underlying binary, you have to place them after a bare set of double-dashes: ` -- `. 

For example, this prints the version of npm:

```
npm create replicate --version
10.1.0
```

And this prints the version of replicate

```
npm create replicate -- --version
1.7.0
```

Following that, if a user wants to run `npm create` and specify a custom model, they'd have to do this:

```
npm create replicate -- --model=yorickvp/llava-13b
```

☝🏼 That works, but it's awkward.

I can't remember if this double-dash business is some really old-school POSIX convention, or some shenanigans invented by the npm maintainers. 

`npx` on the other hand doesn't do this. You pass it flags and it sends those flags to your program, as you would expect.

So I think we need to go back to recommending `npx create-replicate`, and that's what this PR does.

Resolves #21 


