### PR TITLE
fix: UTM source

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -58,7 +58,7 @@ if (process.env.REPLICATE_API_TOKEN) {
   const question = promisify(rl.question).bind(rl)
   const answer = await question('Open your browser to copy a Replicate API token? (Y/n) ')
   if (answer.toLowerCase() === 'y' || answer === '') {
-    await open('https://replicate.com/account/api-tokens?utm_campaign=create-replicate&utm_source=create-replicate')
+    await open('https://replicate.com/account/api-tokens?utm_campaign=create-replicate&utm_source=project')
     const token = readlineSync.question('Paste your API token here: ', { hideEchoBack: true })
 
     // Add the pasted token to the user's local .env file for when they run their project


### PR DESCRIPTION
Replicate.com doesn't seem to like this URL:

https://replicate.com/account/api-tokens?utm_campaign=create-replicate&utm_source=create-replicate

But it's fine with this one:

https://replicate.com/account/api-tokens?utm_campaign=create-replicate&utm_source=project

Maybe something with RudderStack not liking the campaign and source to have the same value? 🤷🏼 

cc @cbh123 