### PR TITLE
feat: get a full prediction, not just output

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -90,6 +90,7 @@ const model = await getModel(args.model)
 // If user has provided a model version, use it. Otherwise, use the latest version
 const modelVersionRegexp = /.*:[a-fA-F0-9]{64}$/
 const modelNameWithVersion = args.model.match(modelVersionRegexp) ? args.model : getModelNameWithVersion(model)
+const version = modelNameWithVersion.split(':')[1]
 
 const inputs = getModelInputs(model)
 
@@ -98,6 +99,7 @@ const indexFile = path.join(targetDir, 'index.js')
 const indexFileContents = fs.readFileSync(indexFile, 'utf8')
 const newContents = indexFileContents
   .replace('{{MODEL}}', modelNameWithVersion)
+  .replace('{{VERSION}}', version)
   .replace('\'{{INPUTS}}\'', JSON5.stringify(inputs, null, 2))
 fs.writeFileSync(indexFile, newContents)
 

--- a/template/index.js
+++ b/template/index.js
@@ -7,9 +7,14 @@ const replicate = new Replicate({
   userAgent: 'https://www.npmjs.com/package/create-replicate'
 })
 const model = '{{MODEL}}'
+const version = '{{VERSION}}'
 const input = '{{INPUTS}}'
 
 console.log({ model, input })
 console.log('Running...')
-const output = await replicate.run(model, { input })
-console.log('Done!', output)
+let prediction = await replicate.predictions.create({ version, input })
+prediction = await replicate.wait(prediction)
+
+console.log('Done!')
+console.log('Output:', prediction.output)
+console.log('View this prediction on the web:', `https://replicate.com/p/${prediction.id}`)


### PR DESCRIPTION
This PR updates the template to use `replicate.predictions.create` instead of `replicate.run`, to start new users off on the right foot, with awareness that there's a whole prediction object available to them, and not just the bare output.

This is useful because:

- It gives people a prediction id, so they have a handle to associate their output with something via API or web.
- It shows stats like prediction time
- It shows the status of the prediction, and logs
- It fits better with the eventuality of teaching users to use webhooks

Working through this revealed to me that the current process for awaiting a prediction with the JS client is not so glamorous: https://github.com/replicate/replicate-javascript/issues/204

Not sure I wanna merge this. Curious to hear thoughts from @replicate/hackers and @replicate/product 