### PR TITLE
fix: key for versionless language models 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 package-lock.json
 template/package-lock.json
 my-replicate-app
-foo
+node_modules

--- a/index.mjs
+++ b/index.mjs
@@ -101,6 +101,7 @@ const inputs = getModelInputs(model)
 console.log('Adding model data and inputs to index.js...')
 const indexFile = path.join(targetDir, 'index.js')
 const indexFileContents = fs.readFileSync(indexFile, 'utf8')
+
 const newContents = indexFileContents
   .replace('{{MODEL}}', modelNameWithVersion)
   .replace('\'{{INPUTS}}\'', JSON5.stringify(inputs, null, 2))

--- a/lib/models.js
+++ b/lib/models.js
@@ -7,7 +7,11 @@ export function getModelInputs (model) {
 }
 
 export function getModelNameWithVersion (model) {
-  return `${model.owner}/${model.name}:${model.latest_version.id}`
+  if (supportsPerTokenPricing(model)) {
+    return `${model.owner}/${model.name}`
+  } else {
+    return `${model.owner}/${model.name}:${model.latest_version.id}`
+  }
 }
 
 export async function getModel (fullModelName) {
@@ -28,4 +32,25 @@ export async function getModel (fullModelName) {
   const model = await replicate.models.get(owner, name)
 
   return model
+}
+
+export function supportsPerTokenPricing (model) {
+  if (model.owner === 'meta') {
+    return new Set([
+      'llama-2-7b',
+      'llama-2-7b-chat',
+      'llama-2-13b',
+      'llama-2-13b-chat',
+      'llama-2-70b',
+      'llama-2-70b-chat'
+    ]).has(model.name)
+  } else if (model.owner === 'mistralai') {
+    return new Set([
+      'mistral-7b-v0.1',
+      'mistral-7b-instruct-v0.2',
+      'mixtral-8x7b-instruct-v0.1'
+    ]).has(model.name)
+  }
+
+  return false
 }

--- a/template/index.js
+++ b/template/index.js
@@ -12,4 +12,5 @@ const input = '{{INPUTS}}'
 console.log({ model, input })
 console.log('Running...')
 const output = await replicate.run(model, { input })
-console.log('Done!', output)
+console.log(output)
+console.log('Done!')


### PR DESCRIPTION
This adds support for generating projects from official language models. Currently, the code generated will use a versioned model name which results in cold boots for the model.

This PR updates the code to detect the current set of official models and use the non-versioned model name. Unfortunately this list has to be hardcoded for the time being as we don't expose which models have this different interface via our API.

The example code also uses the streaming API example, again this is special cased to the language models we know support streaming because this property is also not exposed via the api.
