### PR TITLE
feat: include documentation links at end of script

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -98,7 +98,6 @@ const modelNameWithVersion = args.model.match(modelVersionRegexp) ? args.model :
 
 const inputs = getModelInputs(model)
 
-console.log('Adding model data and inputs to index.js...')
 const indexFile = path.join(targetDir, 'index.js')
 const indexFileContents = fs.readFileSync(indexFile, 'utf8')
 const newContents = indexFileContents
@@ -109,9 +108,17 @@ fs.writeFileSync(indexFile, newContents)
 console.log('App created successfully!')
 
 if (args['run-after-setup']) {
-  console.log(`Running command: \`node ${args.packageName}/index.js\``)
+  console.log(`Running command: \`node ${args.packageName}/index.js\`\n`)
+  console.log('--- START OF OUTPUT ---')
   execSync('node index.js', { cwd: targetDir, stdio: 'inherit' })
+  console.log('--- END OF OUTPUT ---')
 } else {
   console.log('To run your app, execute the following command:')
   console.log(`cd ${args.packageName} && node index.js`)
 }
+
+console.log('')
+console.log('To learn more about configuring this model check out the documentation:')
+console.log(` - Model API Documentation: https://replicate.com/${model.owner}/${model.name}/api`)
+console.log(' - Repliacte Documentation: https://replicate.com/docs/get-started/nodejs')
+console.log(' - Replicate JavaScript Client: https://github.com/replicate/replicate-javascript#readme')

--- a/index.mjs
+++ b/index.mjs
@@ -120,5 +120,5 @@ if (args['run-after-setup']) {
 console.log('')
 console.log('To learn more about configuring this model check out the documentation:')
 console.log(` - Model API Documentation: https://replicate.com/${model.owner}/${model.name}/api`)
-console.log(' - Repliacte Documentation: https://replicate.com/docs/get-started/nodejs')
+console.log(' - Replicate Documentation: https://replicate.com/docs/get-started/nodejs')
 console.log(' - Replicate JavaScript Client: https://github.com/replicate/replicate-javascript#readme')

--- a/template/index.js
+++ b/template/index.js
@@ -9,7 +9,9 @@ const replicate = new Replicate({
 const model = '{{MODEL}}'
 const input = '{{INPUTS}}'
 
-console.log({ model, input })
+console.log('Using model: %s', model)
+console.log('With input: %O', input)
+
 console.log('Running...')
 const output = await replicate.run(model, { input })
 console.log('Done!', output)


### PR DESCRIPTION
This has made some minor changes to the output of the script for readability purposes:

1. We now include some extra links at the bottom of the script output to point to documentation for Replicate and the JS client.
2. We clearly delineate output of the running program from the script itself.
3. We describe the logging of the input/output rather than just dumping a JS object.

```
% npx create-replicate
Creating project "my-replicate-app"...
Model: stability-ai/sdxl...
Copying files...
Adding API token r8_03 to .env file...
Setting package name...
Installing dependencies...
Fetching model metadata using Replicate API...
Adding model data and inputs to index.js...
App created successfully!
Running command: `node my-replicate-app/index.js`

--- START OF OUTPUT ---
Using model: stability-ai/sdxl:39ed52f2a78e934b3ba6e2a89f5b1c712de7dfea535525255b1aa35c5565e08b
With input: {
  width: 768,
  height: 768,
  prompt: 'An astronaut riding a rainbow unicorn, cinematic, dramatic',
  refine: 'expert_ensemble_refiner',
  scheduler: 'K_EULER',
  lora_scale: 0.6,
  num_outputs: 1,
  guidance_scale: 7.5,
  apply_watermark: false,
  high_noise_frac: 0.8,
  negative_prompt: '',
  prompt_strength: 0.8,
  num_inference_steps: 25
}
Running...
Done! [
  'https://replicate.delivery/pbxt/Jey2mduRkWxqKCuxiDXs1eaej9frBenj82MBZi6z4SUOOiXTC/out-0.png'
]
--- END OF OUTPUT ---

To learn more about configuring this model check out the documentation:
 - Model API Documentation: https://replicate.com/stability-ai/sdxl/api
 - Repliacte Documentation: https://replicate.com/docs/get-started/nodejs
 - Replicate JavaScript Client: https://github.com/replicate/replicate-javascript#readme
```
